### PR TITLE
Using Reflect.get(target, key) instead of target[key]

### DIFF
--- a/cjs/accessor.js
+++ b/cjs/accessor.js
@@ -8,7 +8,7 @@ const {
 } = require('./object.js');
 
 const handler = {
-  get: (target, name) => {
+  get(target, name) {
     const context = target;
     while (!hasOwnProperty(target, name))
       target = getPrototypeOf(target);

--- a/cjs/bound.js
+++ b/cjs/bound.js
@@ -1,10 +1,11 @@
 'use strict';
 const {Proxy} = require('./proxy.js');
-const {bind} = require('./function.js');
+const {bind, get} = require('./function.js');
 
 const handler = {
-  get: (target, name) => bind(target[name], target)
+  get(target, name) {
+    return bind(get(target, name), target);
+  }
 };
-
 const bound = target => new Proxy(target, handler);
 exports.bound = bound;

--- a/cjs/function.js
+++ b/cjs/function.js
@@ -2,7 +2,6 @@
 const {Proxy} = require('./proxy.js');
 
 const {apply: a, bind: b, call: c} = Function;
-
 const apply = c.bind(a);
 exports.apply = apply;
 const bind = c.bind(b);
@@ -10,14 +9,22 @@ exports.bind = bind;
 const call = c.bind(c);
 exports.call = call;
 
+const {get: g} = Reflect;
+const get = bind(c, g, Reflect);
+exports.get = get;
+
 const applierHandler = {
-  get: (target, name) => bind(a, target[name])
+  get(target, name) {
+    return bind(a, get(target, name));
+  }
 };
 const applier = target => new Proxy(target, applierHandler);
 exports.applier = applier;
 
 const callerHandler = {
-  get: (target, name) => bind(c, target[name])
+  get(target, name) {
+    return bind(c, get(target, name));
+  }
 };
 const caller = target => new Proxy(target, callerHandler);
 exports.caller = caller;

--- a/esm/accessor.js
+++ b/esm/accessor.js
@@ -7,7 +7,7 @@ import {
 } from './object.js';
 
 const handler = {
-  get: (target, name) => {
+  get(target, name) {
     const context = target;
     while (!hasOwnProperty(target, name))
       target = getPrototypeOf(target);

--- a/esm/bound.js
+++ b/esm/bound.js
@@ -1,8 +1,9 @@
 import {Proxy} from './proxy.js';
-import {bind} from './function.js';
+import {bind, get} from './function.js';
 
 const handler = {
-  get: (target, name) => bind(target[name], target)
+  get(target, name) {
+    return bind(get(target, name), target);
+  }
 };
-
 export const bound = target => new Proxy(target, handler);

--- a/esm/function.js
+++ b/esm/function.js
@@ -1,17 +1,23 @@
 import {Proxy} from './proxy.js';
 
 const {apply: a, bind: b, call: c} = Function;
-
 export const apply = c.bind(a);
 export const bind = c.bind(b);
 export const call = c.bind(c);
 
+const {get: g} = Reflect;
+export const get = bind(c, g, Reflect);
+
 const applierHandler = {
-  get: (target, name) => bind(a, target[name])
+  get(target, name) {
+    return bind(a, get(target, name));
+  }
 };
 export const applier = target => new Proxy(target, applierHandler);
 
 const callerHandler = {
-  get: (target, name) => bind(c, target[name])
+  get(target, name) {
+    return bind(c, get(target, name));
+  }
 };
 export const caller = target => new Proxy(target, callerHandler);

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -6,7 +6,7 @@ const allBoundsFor = Class => {
   const $Class = bound(Class);
   const $class = [];
   for (const key of ownKeys(Class)) {
-    if (typeof Class[key] === 'function')
+    if (typeof key !== 'symbol' && typeof Class[key] === 'function')
       $class.push($Class[key]);
   }
   return $class;


### PR DESCRIPTION
performance seems OK, what matters is that the receiver is not passed along or it's a mess (it throws Errors because it returns a proxy itself each time).